### PR TITLE
Allow to select which Geocoding provider to use

### DIFF
--- a/leaflet-map-query.php
+++ b/leaflet-map-query.php
@@ -40,7 +40,7 @@
                     $addresses = preg_split('/\s?[;|\/]\s?/', $addresses);
                     foreach ($addresses as $address) {
                         if (trim($address)) {
-                            $geocoded = $this::dawa_geocode($address);
+                            $geocoded = $this::osm_geocode($address);
                             $locations[] = Array($geocoded->{'lat'}, $geocoded->{'lng'});
                         }
                     }
@@ -64,7 +64,7 @@
             }
         } else {
             $place_flag = true;
-            $locations[0] = $this::dawa_geocode($the_place->address);
+            $locations[0] = $this::osm_geocode($the_place->address);
             $prad = $the_place->rad;
             $plat = $locations[0][0];
             $plng = $locations[0][1];                        

--- a/leaflet-map-query.php
+++ b/leaflet-map-query.php
@@ -40,7 +40,7 @@
                     $addresses = preg_split('/\s?[;|\/]\s?/', $addresses);
                     foreach ($addresses as $address) {
                         if (trim($address)) {
-                            $geocoded = $this::osm_geocode($address);
+                            $geocoded = $this::geocoding($address);
                             $locations[] = Array($geocoded->{'lat'}, $geocoded->{'lng'});
                         }
                     }
@@ -64,7 +64,7 @@
             }
         } else {
             $place_flag = true;
-            $locations[0] = $this::osm_geocode($the_place->address);
+            $locations[0] = $this::geocoding($the_place->address);
             $prad = $the_place->rad;
             $plat = $locations[0][0];
             $plng = $locations[0][1];                        

--- a/style.css
+++ b/style.css
@@ -33,7 +33,7 @@ p {
 	width:70%;
 	float:right;
 }
-.input-group .regular-text {
+.input-group .regular-text, .input-group .select {
 	width:100%;
 }
 .helptext {

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -1,6 +1,7 @@
 <?php
 $defaults = $this::$defaults;
 unset($defaults['serialized']);
+$choices = $this::$choices;
 
 if (isset($_POST['submit'])) {
 	/* copy and overwrite $post for checkboxes */
@@ -64,11 +65,23 @@ if (isset($_POST['submit'])) {
 			?>
 				<input class="checkbox" name="<?php echo $k; ?>" type="checkbox" id="<?php echo $k; ?>"<?php if (get_option($k, $v)) echo ' checked="checked"' ?> />
 			<?php
-			} 
+			} elseif ($type === 'selects' && array_key_exists($k, $choices)) {
+			?>
+                <select class="select" name="<?php echo $k; ?>" id="<?php echo $k; ?>">
+                <?php
+                foreach ($choices[$k] as $o=>$n) {
+                ?>
+                    <option value="<?php echo $o; ?>"<?php if (get_option($k, $v) == $o) echo ' selected' ?>><?php echo $n; ?></option>
+                <?php
+                }
+                ?>
+                </select>
+			<?php
+			}
 			?>
 			</span>
 		</label>
-		<?php 
+		<?php
 		if (array_key_exists($k, $this::$helptext)) {
 		?>
 		<div class="helptext">


### PR DESCRIPTION
It adds OpenStreetMap Nominatim Geocoding provider and allows to select which one to use to geocode addresses.

To make it possible, a new type `selects` has been added to the **defaults** property for which choices are retrieved from the new **choices** property - the key must be the same in both arrays.
